### PR TITLE
Eliminate creating a default engine in GraalPythonScriptEngineFactory…

### DIFF
--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/OpenhabGraalPythonScriptEngine.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/OpenhabGraalPythonScriptEngine.java
@@ -12,7 +12,8 @@
  */
 package org.openhab.automation.pythonscripting.internal;
 
-import static org.openhab.core.automation.module.script.ScriptEngineFactory.*;
+import static org.openhab.core.automation.module.script.ScriptEngineFactory.CONTEXT_KEY_ENGINE_IDENTIFIER;
+import static org.openhab.core.automation.module.script.ScriptEngineFactory.CONTEXT_KEY_EXTENSION_ACCESSOR;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,9 +81,6 @@ public class OpenhabGraalPythonScriptEngine
     private String engineIdentifier; // this field is very helpful for debugging, please do not remove it
 
     private boolean initialized = false;
-    private final boolean jythonEmulation;
-
-    public String testString = "Test String";
 
     /**
      * Creates an implementation of ScriptEngine {@code (& Invocable)}, wrapping the contained engine,
@@ -91,7 +89,6 @@ public class OpenhabGraalPythonScriptEngine
     public OpenhabGraalPythonScriptEngine(boolean jythonEmulation) {
         // JSDependencyTracker jsDependencyTracker) {
         super(null); // delegate depends on fields not yet initialised, so we cannot set it immediately
-        this.jythonEmulation = jythonEmulation;
 
         script_bundle = FrameworkUtil.getBundle(org.openhab.core.automation.module.script.ScriptEngineManager.class);
 
@@ -181,6 +178,10 @@ public class OpenhabGraalPythonScriptEngine
 
     @Override
     public void close() {
+        try {
+            ((AutoCloseable) ENGINE).close();
+        } catch (Exception e) {
+        }
     }
 
     /**

--- a/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
+++ b/bundles/org.openhab.automation.pythonscripting/src/main/java/org/openhab/automation/pythonscripting/internal/PythonScriptEngineFactory.java
@@ -48,14 +48,6 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
     private boolean jythonEmulation = false;
 
     public static final String SCRIPT_TYPE = "py3";
-
-    // private static final GraalPythonScriptEngineFactory factory = new GraalPythonScriptEngineFactory();
-
-    // private final List<String> scriptTypes = (List<String>) Stream.of(factory.getExtensions(),
-    // factory.getMimeTypes()) //
-    // .flatMap(List::stream) //
-    // .toList();
-
     private final List<String> scriptTypes = Arrays.asList(PythonScriptEngineFactory.SCRIPT_TYPE);
 
     @Activate
@@ -77,8 +69,6 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public void scopeValues(ScriptEngine scriptEngine, Map<String, Object> scopeValues) {
-        logger.debug("Scope Values: {}", scopeValues);
-
         for (Entry<String, Object> entry : scopeValues.entrySet()) {
             scriptEngine.put(entry.getKey(), entry.getValue());
         }
@@ -92,13 +82,6 @@ public class PythonScriptEngineFactory implements ScriptEngineFactory {
         return new OpenhabGraalPythonScriptEngine(jythonEmulation);
         // return new DebuggingGraalScriptEngine<>(new OpenhabGraalPythonScriptEngine(jythonEmulation));
     }
-
-    /*
-     * @Override
-     * public @Nullable ScriptDependencyTracker getDependencyTracker() {
-     * return jsDependencyTracker;
-     * }
-     */
 
     @Modified
     protected void modified(Map<String, ?> config) {

--- a/bundles/org.openhab.automation.pythonscripting/test.py
+++ b/bundles/org.openhab.automation.pythonscripting/test.py
@@ -1,1 +1,0 @@
-/Users/jeff/openhab/conf/automation/python/test.py


### PR DESCRIPTION
… - not needed since one is created in OpenhabGraalPythonScriptEngine

cleanup
